### PR TITLE
Added libinput compatibility

### DIFF
--- a/libsuinput/src/suinput.c
+++ b/libsuinput/src/suinput.c
@@ -57,6 +57,7 @@ int suinput_emit_click(const int uinput_fd, const uint16_t key_code)
 {
         if (suinput_emit(uinput_fd, EV_KEY, key_code, 1) == -1)
                 return -1;
+        suinput_syn(uinput_fd); //Required for mouse click to register correctly
         return suinput_emit(uinput_fd, EV_KEY, key_code, 0);
 }
 
@@ -78,6 +79,7 @@ int suinput_emit_combo(const int uinput_fd, const uint16_t *const key_codes,
                                   combination is missing or broken. */
                 }
         }
+        suinput_syn(uinput_fd); //Required for mouse click to register correctly
 
         /* Try to release every pressed key, no matter what. */
         while (i--) {


### PR DESCRIPTION
Fix for issue #26.

Testing Done (user_input is a script of mine that, among other things, defines a uinput device):

```
>>> import uinput as ui
>>> import user_input
>>> user_input.device.emit(ui.KEY_1, 1, syn=False)
>>> user_input.device.emit(ui.KEY_1, 0, syn=False)
>>> user_input.device.syn()
>>> user_input.device.emit_combo([ui.KEY_1, ui.KEY_2], syn=False)
>>> user_input.device.syn()
>>> user_input.device.emit_combo([ui.KEY_1, ui.KEY_2], syn=False)
>>> user_input.device.emit(ui.KEY_1, 1, syn=False)
>>> user_input.device.emit(ui.KEY_1, 0, syn=False)
>>> user_input.device.syn()
>>> user_input.device.emit_click(ui.KEY_1, syn=False)
>>> user_input.device.syn()
>>> user_input.device.emit_combo([ui.KEY_1, ui.KEY_2], syn=False)
>>> user_input.device.emit(ui.KEY_1, 1, syn=False)
>>> user_input.device.emit(ui.KEY_1, 0, syn=False)
>>> user_input.device.emit_click(ui.KEY_1, syn=False)
>>> user_input.device.syn()
>>> user_input.device.emit_combo([ui.KEY_1, ui.BTN_LEFT], syn=False)
>>> user_input.device.syn()
>>> user_input.device.emit_combo([ui.KEY_1, ui.BTN_LEFT])
```