### PR TITLE
Add support for Python 3.11

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -83,7 +83,7 @@ def _error_handler(result, fn, args):
 def fdopen():
     return _libsuinput.suinput_open()
 
-_libsuinput_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "_libsuinput" + sysconfig.get_config_var("SO")))
+_libsuinput_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "_libsuinput" + sysconfig.get_config_var("EXT_SUFFIX")))
 _libsuinput = ctypes.CDLL(_libsuinput_path, use_errno=True)
 _libsuinput.suinput_open.errcheck = _open_error_handler
 _libsuinput.suinput_enable_event.errcheck = _error_handler


### PR DESCRIPTION
The "SO" sysconfig has been removed in Python 3.11.

"EXT_SUFFIX" has been available since Python 3.4.