### PR TITLE
Updated deprecated sysconfig variable

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -83,7 +83,10 @@ def _error_handler(result, fn, args):
 def fdopen():
     return _libsuinput.suinput_open()
 
-_libsuinput_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "_libsuinput" + sysconfig.get_config_var("SO")))
+config_var = sysconfig.get_config_var("EXT_SUFFIX")
+if not config_var:
+    raise  RuntimeError("Failed to get EXT_SUFFIX")
+_libsuinput_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "_libsuinput" + config_var))
 _libsuinput = ctypes.CDLL(_libsuinput_path, use_errno=True)
 _libsuinput.suinput_open.errcheck = _open_error_handler
 _libsuinput.suinput_enable_event.errcheck = _error_handler

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -83,7 +83,7 @@ def _error_handler(result, fn, args):
 def fdopen():
     return _libsuinput.suinput_open()
 
-config_var = sysconfig.get_config_var("EXT_SUFFIX")
+config_var = sysconfig.get_config_var("EXT_SUFFIX") or sysconfig.get_config_var("SO")
 if not config_var:
     raise  RuntimeError("Failed to get EXT_SUFFIX")
 _libsuinput_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "_libsuinput" + config_var))


### PR DESCRIPTION
The config var "SO" is deprecated as per this error message running sysconfig.get_config_var("SO") in a command line
<stdin>:1: DeprecationWarning: SO is deprecated, use EXT_SUFFIX
I've updated the line to EXT_SUFFIX with the deprecated "SO" as fallback, the library works as expected again