### PR TITLE
Replace distutils with setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 import errno
 import subprocess
 
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 
 libudev_so = "libudev.so.1"
 
@@ -53,11 +53,7 @@ setup(name='python-uinput',
         "Operating System :: POSIX :: Linux",
         "Topic :: System :: Operating System Kernels :: Linux",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.6",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.1",
         "Programming Language :: Python :: 3.2",
         "Programming Language :: Python :: 3.4",
         ],

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -36,7 +36,7 @@ from __future__ import absolute_import
 import ctypes
 import errno
 import os
-import distutils.sysconfig as sysconfig
+import sysconfig
 
 from .ev import *
 


### PR DESCRIPTION
The distutils module was formally removed in Python 3.12. As a result, replace its usage with setuptools.

This breaks compatibility with Python 3.1 or earlier. The setup.py file is updated accordingly to mark this compatibility.

This commit partially reverts
https://github.com/tuomasjjrasanen/python-uinput/commit/1e7613e4056dcf1b43e6d28193f2ef73034d7b14 .

This pull request closes: tuomasjjrasanen/python-uinput#46 .